### PR TITLE
Add a CLI option to set the config file path

### DIFF
--- a/src/hello_config.rs
+++ b/src/hello_config.rs
@@ -26,7 +26,11 @@ pub(crate) async fn setup_hola(opts: &Opts) -> Result<Proxy> {
         "Setting up Hola proxy. Regen: {} / Discard: {} / Country: {}",
         opts.regen_creds, opts.discard_creds, opts.country
     );
-    let mut config: Config = confy::load(CRATE_NAME, None)?;
+    let mut config: Config = if let Some(path) = &opts.config_file {
+        confy::load_path(path)?
+    } else {
+        confy::load(CRATE_NAME, None)?
+    };
     let uuid = if !opts.regen_creds { config.uuid } else { None };
     let (bg, uuid) = hello::background_init(uuid).await.context("Hola init")?;
     config.uuid = Some(uuid);
@@ -56,7 +60,11 @@ pub(crate) async fn setup_hola(opts: &Opts) -> Result<Proxy> {
             "Saving Hola credentials to {}",
             confy::get_configuration_file_path(CRATE_NAME, None)?.display()
         );
-        confy::store(CRATE_NAME, None, &config)?;
+        if let Some(path) = &opts.config_file {
+            confy::store_path(path, &config)?;
+        } else {
+            confy::store(CRATE_NAME, None, &config)?;
+        }
     }
     Ok(Proxy::all(proxy)?.basic_auth(&login, &password))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
-#[cfg(feature = "tls")]
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -119,6 +118,9 @@ pub(crate) struct Opts {
     /// copy-or-default system.
     #[arg(short, long, env = "LUMINOUS_TTV_USER_AGENT")]
     user_agent: Option<HeaderValue>,
+    /// Path to configuration file. Uses system default if left unspecified.
+    #[arg(long, env = "LUMINOUS_TTV_CONFIG_FILE")]
+    config_file: Option<PathBuf>,
 }
 
 // The "kimne..." client ID is shown in the clear if you load the main page.


### PR DESCRIPTION
Hey, this change allows the user to set the config file path using a CLI flag or an environment variable.

My use case: Since luminous-ttv is a network-facing service, I want to restrict its system access as much as possible, including access to the home directory. Hence, I want to change the path where the config file is located. (This is already possible by changing the HOME environment variable, but I'd like to use a less hacky method.)

The default behaviour remains the same, so existing deployments are unaffected.