### PR TITLE
chore: Update to usher v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,29 +1042,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy-regex"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191898e17ddee19e60bccb3945aa02339e81edd4a8c50e21fd4d48cdecda7b29"
-dependencies = [
- "lazy-regex-proc_macros",
- "once_cell",
- "regex",
-]
-
-[[package]]
-name = "lazy-regex-proc_macros"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35dc8b0da83d1a9507e12122c80dea71a9c7c613014347392483a83ea593e04"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,11 +1105,11 @@ dependencies = [
  "extend",
  "http",
  "isocountry",
- "lazy-regex",
  "nu-ansi-term",
  "once_cell",
  "phf",
  "rand",
+ "regex",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
@@ -1447,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "luminous-ttv"
 version = "0.5.12"
-authors = ["Malloc Voidstar <1284317+AlyoshaVasilieva@users.noreply.github.com>"]
+authors = [
+	"Malloc Voidstar <1284317+AlyoshaVasilieva@users.noreply.github.com>",
+]
 edition = "2021"
 repository = "https://github.com/AlyoshaVasilieva/luminous-ttv"
 license = "GPL-3.0-only"
@@ -19,7 +21,7 @@ rand = "0.9.1"
 const_format = "0.2.18"
 url = "2.2.2"
 extend = "1.1.2"
-lazy-regex = { version = "3.0.2", default-features = false, features = ["std", "perf"], optional = true }
+regex = { version = "1.12.2", optional = true }
 cfg-if = "1.0"
 phf = { version = "0.13.1", features = ["macros"] }
 reqwest-middleware = { version = "0.4", features = ["json"] }
@@ -33,14 +35,23 @@ serde-tuple-vec-map = { version = "1.0", optional = true }
 
 # Axum and related deps
 axum = { version = "0.8.1", features = ["http2", "json"] }
-axum-extra = { version = "0.12.1", default-features = false, features = ["typed-header"] }
+axum-extra = { version = "0.12.1", default-features = false, features = [
+	"typed-header",
+] }
 axum-server = "0.8"
 tokio = { version = "1.13", features = ["macros", "rt-multi-thread"] }
-tower = { version = "0.5.1", features = ["limit", "load-shed", "timeout", "util"] }
+tower = { version = "0.5.1", features = [
+	"limit",
+	"load-shed",
+	"timeout",
+	"util",
+] }
 tower-http = { version = "0.6", features = ["cors", "set-header"] }
 http = "1.1"
 
-tracing = { version = "0.1", features = ["release_max_level_debug"] } # disable trace in releases
+tracing = { version = "0.1", features = [
+	"release_max_level_debug",
+] } # disable trace in releases
 tracing-subscriber = "0.3"
 
 [dependencies.reqwest]
@@ -55,12 +66,14 @@ nu-ansi-term = "0.50"
 [features]
 default = ["hola"]
 hola = ["confy", "isocountry", "serde-tuple-vec-map", "uuid"]
-gzip = ["tower-http/compression-gzip"] # compress responses
+gzip = ["tower-http/compression-gzip"]                        # compress responses
 # Note: zstd seems to have browser support now (use level 1 or 2).
 # Investigate shared dictionaries. Not sure if they're usable yet, but they'd save ~30% per M3U.
-tls = ["axum-server/tls-rustls"] # support listening as HTTPS, without needing a reverse proxy
+tls = [
+	"axum-server/tls-rustls",
+] # support listening as HTTPS, without needing a reverse proxy
 true-status = [] # extended status endpoint that simulates a user's request flow
-redact-ip = ["lazy-regex"] # try to hide server IP in responses (no guarantees)
+redact-ip = ["dep:regex"] # try to hide server IP in responses (no guarantees)
 
 [profile.release]
 codegen-units = 1
@@ -69,7 +82,7 @@ lto = true
 # for `cargo deb`
 [package.metadata.deb]
 license-file = ["LICENSE-GPL.txt", "0"]
-maintainer-scripts = "debian/maint-scripts" # empty, see cargo-deb docs
+maintainer-scripts = "debian/maint-scripts"                                   # empty, see cargo-deb docs
 systemd-units = { enable = false, unit-scripts = "debian" }
 default-features = false
 features = ["gzip", "tls", "true-status", "redact-ip", "reqwest/hickory-dns"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -427,8 +427,8 @@ async fn get_m3u8(client: &Client, pd: &ProcessData, token: PlaybackAccessToken)
     {
         // if the server is behind Cloudflare or similar, the playlist exposes the real IP, which
         // removes all the DDoS protection
-        let user_ip = lazy_regex::regex!(r#"USER-IP="(([[:digit:]]{1,3}\.){3}[[:digit:]]{1,3})""#);
-        Ok(user_ip.replace(&m3u, r#"USER-IP="1.1.1.1""#).into_owned())
+        let user_ip = regex::Regex::new(r#"USER-IP",VALUE="[^"]+"#).unwrap();
+        Ok(user_ip.replace(&m3u, r#"USER-IP",VALUE="1.1.1.1"#).into_owned())
     }
     #[cfg(not(feature = "redact-ip"))]
     Ok(m3u)
@@ -577,8 +577,8 @@ impl StreamID {
     pub(crate) fn get_url(&self) -> String {
         const BASE: &str = "https://usher.ttvnw.net/";
         match &self {
-            Self::Live(channel) => format!("{BASE}api/channel/hls/{channel}.m3u8"),
-            Self::VOD(id) => format!("{BASE}vod/{id}.m3u8"),
+            Self::Live(channel) => format!("{BASE}api/v2/channel/hls/{channel}.m3u8"),
+            Self::VOD(id) => format!("{BASE}vod/v2/{id}.m3u8"),
         }
     }
     pub(crate) fn data(&self) -> &str {


### PR DESCRIPTION
Supersedes and/or closes #27, although Imo #27's much higher prio to be merged.
Relates to https://github.com/AlyoshaVasilieva/luminous-ttv-ext/pull/8.

It'll probably be good to have these on their own paths, in order to keep legacy support. `#EXT-X-MEDIA.NAME` has been split into `#EXT-X-STREAM-INF.IVS-NAME` for quality, and source's now identified by `#EXT-X-STREAM-INF.IVS-VARIANT-SOURCE`. So there are some parsing differences.